### PR TITLE
Fix bug in requirements.txt template

### DIFF
--- a/templates/pyproject/flake.nix
+++ b/templates/pyproject/flake.nix
@@ -4,7 +4,7 @@
   inputs.pyproject.url = "github:nix-community/pyproject.nix";
   inputs.pyproject.inputs.nixpkgs.follows = "nixpkgs";
 
-  outputs = { nixpkgs, pyproject }:
+  outputs = { nixpkgs, pyproject, ... }:
     let
       inherit (nixpkgs) lib;
 

--- a/templates/requirements-txt/flake.nix
+++ b/templates/requirements-txt/flake.nix
@@ -11,6 +11,7 @@
     { nixpkgs
     , flake-utils
     , pyproject-nix
+    , ...
     }:
     let
       pyproject = import (pyproject-nix + "/lib") { inherit (nixpkgs) lib; };


### PR DESCRIPTION
In my environment, I get the following error when I attempt to run this Flake:

```text
error: function 'outputs' called with unexpected argument 'self'

       at /nix/store/m8vmipjaw53ihc76vs40px1qm062plmy-source/flake.nix:11:5:

           10|   outputs =
           11|     { nixpkgs
             |     ^
           12|     , flake-utils
```

Adding `self` as an argument fixes the error.