### PR TITLE
Fix grammar error in requirements-txt/flake.nix

### DIFF
--- a/templates/requirements-txt/flake.nix
+++ b/templates/requirements-txt/flake.nix
@@ -5,7 +5,7 @@
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   inputs.pyproject-nix.url = "github:nix-community/pyproject.nix";
-  inputs.pyproject-nix.flake = false; # Don't use the pyproject.nix flake directly to avoid it's inputs in our closure
+  inputs.pyproject-nix.flake = false; # Don't use the pyproject.nix flake directly to avoid its inputs in our closure
 
   outputs =
     { nixpkgs


### PR DESCRIPTION
This fixes a minor grammar issue in one of the flake.nix comments. The spelling should be "its" as the context indicates a possessive form rather than a contraction of "it is."