### PR TITLE
isPlatformTagCompatible: lift constraint on darwinSdkVersion

### DIFF
--- a/lib/pypa.nix
+++ b/lib/pypa.nix
@@ -236,8 +236,6 @@ lib.fix (self: {
           platform.isDarwin
           &&
           ((arch == "universal2" && (platform.darwinArch == "arm64" || platform.darwinArch == "x86_64")) || arch == platform.darwinArch)
-          &&
-          compareVersions platform.darwinSdkVersion "${major}.${minor}" >= 0
         )
       )
     else if platformTag == "win32" then (platform.isWindows && platform.is32Bit && platform.isx86)


### PR DESCRIPTION
darwinSdkVersion is hardcoded to 11 for aarch64-darwin systems in nixpkgs.
This means that wheels with macosx_12_[...] would never be selected, while they seem to be compatible for quite a while already.
