### PR TITLE
fix: error message in link_dependencies collision

### DIFF
--- a/build/hooks/make-venv.py
+++ b/build/hooks/make-venv.py
@@ -172,7 +172,15 @@ def link_dependency(dep_root: Path, out_root: Path) -> None:
             if stat.S_ISLNK(st_mode):
                 shutil.copy(path, out.joinpath(path.name), follow_symlinks=False)
             elif stat.S_ISREG(st_mode):
-                os.symlink(path, out.joinpath(path.name))
+                target_path = out.joinpath(path.name)
+                try:
+                    os.symlink(path, target_path)
+                except FileExistsError:
+                    msg = f"Linking path {target_path} to {path} failed because it already existed."
+                    if Path(target_path).is_symlink():
+                        msg += f" It is a symlink resolving to {Path(target_path).resolve()}."
+                    raise FileExistsError(msg)
+
             elif stat.S_ISDIR(st_mode):
                 _link(path, out.joinpath(path.name))
             else:


### PR DESCRIPTION
Just another case where we can exactly pinpoint the two causing pkgs.

Previous error message

> FileExistsError: [Errno 17] File exists: '/nix/store/jyzfv9z981s6x1kqrf2k4k9hh0l5na38-cfxdb-23.12.1/LICENSE' -> '/nix/store/b2ayknndk4w7hhydibf32z7vi6y2r57p-test-venv/LICENSE'


new

> FileExistsError: Trying to link /nix/store/jyzfv9z981s6x1kqrf2k4k9hh0l5na38-cfxdb-23.12.1/LICENSE to /nix/store/4k7px3i153anj7h46fiw29qanvrz7iny-test-venv/LICENSE, but that already exists. It links to /nix/store/nlkfllagsi9x98agw7rlxgvh5l3h11jx-crossbar-22.6.1/LICENSE.
