### PR TITLE
pep508.mkEnviron: Set reasonable defaults for Linux & Darwin

### DIFF
--- a/lib/expected/pep508.mkEnviron.testPypy3Linux.json
+++ b/lib/expected/pep508.mkEnviron.testPypy3Linux.json
@@ -33,7 +33,18 @@
   },
   "platform_release": {
     "type": "platform_release",
-    "value": ""
+    "value": {
+      "dev": null,
+      "epoch": 0,
+      "local": null,
+      "post": null,
+      "pre": null,
+      "release": [
+        6,
+        10
+      ],
+      "str": "6.10"
+    }
   },
   "platform_system": {
     "type": "string",

--- a/lib/expected/pep508.mkEnviron.testPython311Darwin.json
+++ b/lib/expected/pep508.mkEnviron.testPython311Darwin.json
@@ -33,7 +33,18 @@
   },
   "platform_release": {
     "type": "platform_release",
-    "value": ""
+    "value": {
+      "dev": null,
+      "epoch": 0,
+      "local": null,
+      "post": null,
+      "pre": null,
+      "release": [
+        20,
+        0
+      ],
+      "str": "20.0"
+    }
   },
   "platform_system": {
     "type": "string",

--- a/lib/expected/pep508.mkEnviron.testPython311DarwinAarch64.json
+++ b/lib/expected/pep508.mkEnviron.testPython311DarwinAarch64.json
@@ -33,7 +33,18 @@
   },
   "platform_release": {
     "type": "platform_release",
-    "value": ""
+    "value": {
+      "dev": null,
+      "epoch": 0,
+      "local": null,
+      "post": null,
+      "pre": null,
+      "release": [
+        20,
+        0
+      ],
+      "str": "20.0"
+    }
   },
   "platform_system": {
     "type": "string",

--- a/lib/expected/pep508.mkEnviron.testPython38Linux.json
+++ b/lib/expected/pep508.mkEnviron.testPython38Linux.json
@@ -33,7 +33,18 @@
   },
   "platform_release": {
     "type": "platform_release",
-    "value": ""
+    "value": {
+      "dev": null,
+      "epoch": 0,
+      "local": null,
+      "post": null,
+      "pre": null,
+      "release": [
+        6,
+        10
+      ],
+      "str": "6.10"
+    }
   },
   "platform_system": {
     "type": "string",

--- a/lib/test.nix
+++ b/lib/test.nix
@@ -27,6 +27,7 @@ let
           implementation ? "cpython",
           isLinux ? false,
           isDarwin ? false,
+          linuxVersion ? "6.10",
           system,
         }:
         {
@@ -154,6 +155,7 @@ let
                 {
                   libc.pname = "glibc";
                   libc.version = "2.37";
+                  libc.linuxHeaders.version = linuxVersion;
                 }
               else if isDarwin then
                 {


### PR DESCRIPTION
These are not perfect. We don't know that `pkgs.linuxHeaders` is actually matching what a user deploys to, or that the Nixpkgs Darwin SDK versions are actually corresponding to the real-world host.

This is however, an improvement, and surely better than leaving platform metadata empty.