### PR TITLE
Fix: Making symlinks in deterministic order

### DIFF
--- a/build/hooks/make-venv.py
+++ b/build/hooks/make-venv.py
@@ -36,7 +36,7 @@ def compare_fds(fa: typing.IO, fb: typing.IO) -> bool:
 def write_bin_dir(bin_dir: Path, bin_out: Path) -> None:
     out_shebang: bytes = f"#!{bin_out}".encode()
 
-    for bin in os.listdir(bin_dir):
+    for bin in sorted(os.listdir(bin_dir)):
         bin_file = bin_dir.joinpath(bin)
         bin_file_out = bin_out.joinpath(bin_file.name)
         st_mode = bin_file.lstat().st_mode
@@ -193,7 +193,7 @@ def link_dependency(dep_root: Path, out_root: Path) -> None:
         except FileExistsError:
             pass
 
-        for filename in os.listdir(root):
+        for filename in sorted(os.listdir(root)):
             path = root.joinpath(filename)
 
             # Special case handle bin/site-packages


### PR DESCRIPTION
The order in which symlinks are created in make-venv is dependent on what os.listdir returns, which in turn is 'disk order', which is undefined.

This can lead to messages like these
```
 builder for '/nix/store/3jzpcky8avqk8avmgz3ysjmnns82zmly-test-venv.drv' failed with exit code 1;
[..snip..]
venv.py", line 205, in _link
       >     raise FileExistsError(msg)
       > FileExistsError: Linking '/nix/store/v256bsm7g2pz7lrszafwd0yqz9y0ybx1-blosc2-2.7.1/lib64/python3.12/site-packages/blosc2/blosc2_ext.cpython-312-x86_64-linux-gnu.so' -> '/nix/store/vhbwbm16clgp4bnr2k679mdag1rrnqbk-test-venv/lib64/python3.12/site-packages/blosc2/blosc2_ext.cpython-312-x86_64-linux-gnu.so' failed, path already exists resolving to '/nix/store/v256bsm7g2pz7lrszafwd0yqz9y0ybx1-blosc2-2.7.1/lib/python3.12/site-packages/blosc2/blosc2_ext.cpython-312-x86_64-linux-gnu.so'
       For full logs, run 'nix log /nix/store/3jzpcky8avqk8avmgz3ysjmnns82zmly-test-venv.drv'.
```

which may or may not disappear on repeated build attempts (!).

This patch doesn't examine the problem much,
but it enforces an order, and it picks the one blosc2 works with.