### PR TITLE
update flit core to work with later nixpkgs

### DIFF
--- a/build/bootstrap.nix
+++ b/build/bootstrap.nix
@@ -42,7 +42,7 @@ let
 
   bootstrap = {
     flit-core = buildBootstrapPackage python3Packages.flit-core {
-      sourceRoot = "${python3Packages.flit-core.src.name}/flit_core";
+      postPatch = "cd flit_core";
       buildPhase = ''
         runHook preBuild
         ${python.interpreter} -m flit_core.wheel

--- a/build/pkgs/flit-core/default.nix
+++ b/build/pkgs/flit-core/default.nix
@@ -10,7 +10,6 @@ stdenv.mkDerivation {
     src
     meta
     patches
-    postPatch
     ;
   nativeBuildInputs = [
     pyprojectHook

--- a/build/pkgs/flit-core/default.nix
+++ b/build/pkgs/flit-core/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation {
     meta
     patches
     ;
+  postPatch = python3Packages.flit-core.postPatch or null;
+  sourceRoot = python3Packages.flit-core.sourceRoot or null;
   nativeBuildInputs = [
     pyprojectHook
   ];

--- a/build/pkgs/flit-core/default.nix
+++ b/build/pkgs/flit-core/default.nix
@@ -8,8 +8,9 @@ stdenv.mkDerivation {
     pname
     version
     src
-    sourceRoot
     meta
+    patches
+    postPatch
     ;
   nativeBuildInputs = [
     pyprojectHook


### PR DESCRIPTION
Fixes an issue where pyproject.nix cannot be used with recent nixos-unstable-small nixpkgs set because of differing definitions of flit-core.